### PR TITLE
Py packaging and more versatile C++ CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+
+CXX = g++
+CXXFLAGS = -g -Wall -std=c++11
+LDLIBS = $(shell pkg-config --cflags --libs opencv)
+VPATH = src/cpp
+
+DeslantImg: main.o
+	$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) -o $@
+
+ifeq (1,$(GPU))
+$(info Compiling for GPU using OpenCL.)
+VPATH += src/cl
+LDLIBS += -lOpenCL
+CXXFLAGS += -DUSE_GPU
+
+DeslantImg: DeslantImgGPU.o CLWrapper.o
+
+else
+$(info Compiling for CPU.)
+
+DeslantImg: DeslantImgCPU.o
+
+endif

--- a/README.md
+++ b/README.md
@@ -50,13 +50,44 @@ Some notes on how to compile the demo manually and how to compile for Windows or
 ### Python GUI
 
 Command line options of `DeslantImgPlot`:
-* `--data`: directory containing the (.png|.jpg|.bmp) input images
-* `--optim_algo`: either do grid search (`grid`), or apply Powell's derivative-free optimizer (`powell`)
-* `--lower_bound`: lower bound of shear values
-* `--upper_bound`: upper bound of shear values
-* `--num_steps`: if grid search is used, this argument defines the number if grid points
-* `--bg_color`: color to fill the gaps of the sheared image that is returned
+```
+usage: DeslantImgPlot [-h] [--data DATA] [--optim_algo {grid,powell}]
+                      [--lower_bound LO] [--upper_bound HI]
+                      [--num_steps STEPS] [--bg_color BG]
 
+optional arguments:
+  -h, --help            show this help message and exit
+  --data DATA           directory containing the (.png|.jpg|.bmp) input images
+  --optim_algo {grid,powell}
+                        either do grid search, or apply Powell's derivative-
+                        free optimizer
+  --lower_bound LO      lower bound of shear values
+  --upper_bound HI      upper bound of shear values
+  --num_steps STEPS     if grid search is used, this argument defines the
+                        number if grid points
+  --bg_color BG         color to fill the gaps of the sheared image that is
+                        returned
+```
+
+### C++ CLI
+
+Command line options of `DeslantImg`:
+```
+Usage: DeslantImg [params] 
+
+	-?, -h, --help, --usage (value:true)
+		print this message
+	--data (value:data)
+		directory to read the input images from
+	--dataout (value:.)
+		directory to write the output images to
+	--bg_color (value:255)
+		color to fill the gaps of the sheared image that is returned
+	--lower_bound (value:-1.0)
+		lower bound of shear values
+	--upper_bound (value:1.0)
+		upper bound of shear values
+```
 
 ### C++ API
 Call function `deslantImg(img, bgcolor)` with the input image (grayscale), and the background color (to fill empty image space).
@@ -76,7 +107,7 @@ const cv::Mat res = htr::deslantImg(img, 255);
 cv::imwrite("out1.png", res);
 ```
 
-### OpenCL API
+### C++ OpenCL API
 The GPU version additionally takes an instance of `CLWrapper` which holds all relevant information needed for OpenCL: `deslantImg(img, bgcolor, clWrapper)`.
 As the construction of a `CLWrapper` instance takes time, it makes sense to only create one instance and use it for all future calls to `deslantImg(img, bgcolor, clWrapper)`. 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Three implementations are provided:
 
 * Use `./build.sh` to build the CPU version, or `./build.sh gpu` to build the GPU version on Linux using g++  
   Alternatively, use `make` to build the CPU version, or `make GPU=1` to build to GPU version.
-* Run `./DeslantImg` (without arguments) to process the images in the `data/` directory
+* Run `./DeslantImg` to process the images in the `data/` directory
 * Two processed images are saved in the repositories root directory
 
 Some notes on how to compile the demo manually and how to compile for Windows or other operating systems:
@@ -73,20 +73,21 @@ optional arguments:
 
 Command line options of `DeslantImg`:
 ```
-Usage: DeslantImg [params] 
+Usage: DeslantImg [params] imagein imageout 
 
 	-?, -h, --help, --usage (value:true)
 		print this message
-	--data (value:data)
-		directory to read the input images from
-	--dataout (value:.)
-		directory to write the output images to
 	--bg_color (value:255)
 		color to fill the gaps of the sheared image that is returned
 	--lower_bound (value:-1.0)
 		lower bound of shear values
 	--upper_bound (value:1.0)
 		upper bound of shear values
+
+	imagein (value:-)
+		path name to read the input image from (or stdin)
+	imageout (value:-)
+		path name to write the output image to (or stdout)
 ```
 
 ### C++ API

--- a/README.md
+++ b/README.md
@@ -14,51 +14,55 @@ Three implementations are provided:
 * OpenCL: each column and shear angle is processed in parallel using OpenCL to compute the optimal shear angle, the remaining work is done on the CPU using OpenCV
 
 
-## Run demo
+## Installation
 
 ### Python
 
-* Install required packages by running `pip install -r requirements.txt`
-* Go to the directory `src/py`
-* Run `python main.py` to process the images in the `data` directory (images taken from IAM and Bentham dataset)
+* Install by running `pip install .`
+* Run `DeslantImgPlot` (without arguments) to process the images in the `data` directory (images taken from IAM and Bentham dataset)
 * This opens a window showing the input image, deslanted image and score values
-* The script can be configured via command line, see available options by running `python main.py -h`
+* The script can be configured via command line, see available options [below](#python-gui), or by running `DeslantImgPlot -h`
 
 ![plot](doc/plot.png)
 
 ### C++ and OpenCL
 
-* Use `./build.sh` to build the CPU version or `./build.sh gpu` to build the GPU version on Linux using g++
-* Run `./DeslantImg` to process the images in the `data/` directory
+* Use `./build.sh` to build the CPU version, or `./build.sh gpu` to build the GPU version on Linux using g++  
+  Alternatively, use `make` to build the CPU version, or `make GPU=1` to build to GPU version.
+* Run `./DeslantImg` (without arguments) to process the images in the `data/` directory
 * Two processed images are saved in the repositories root directory
 
 Some notes on how to compile the demo manually and how to compile for Windows or other operating systems:
 
-* Build **CPU** implementation on Linux (OpenCV must be installed):
-```g++ --std=c++11 src/cpp/main.cpp src/cpp/DeslantImgCPU.cpp `pkg-config --cflags --libs opencv` -o DeslantImg ```
-* If the macro **USE_GPU** is defined, the computation takes place on the GPU. Build **CPU and GPU** implementation on Linux (OpenCV and OpenCL must be installed):
-```g++ --std=c++11 -D USE_GPU src/cpp/main.cpp src/cpp/DeslantImgCPU.cpp src/cpp/DeslantImgGPU.cpp src/cpp/CLWrapper.cpp `pkg-config --cflags --libs opencv` -lOpenCL -o DeslantImg```
+* Build **CPU** implementation on Linux (OpenCV must be installed, `libopencv-dev`):
+
+        g++ --std=c++11 src/cpp/main.cpp src/cpp/DeslantImgCPU.cpp `pkg-config --cflags --libs opencv` -o DeslantImg
+
+* If the macro **USE_GPU** is defined, the computation takes place on the GPU. To build **CPU and GPU** implementation on Linux (OpenCV _and_ OpenCL must be installed, `libopencv-dev nvidia-opencl-dev`):
+
+        g++ --std=c++11 -D USE_GPU src/cpp/main.cpp src/cpp/DeslantImgCPU.cpp src/cpp/DeslantImgGPU.cpp src/cpp/CLWrapper.cpp `pkg-config --cflags --libs opencv` -lOpenCL -o DeslantImg
+
 * On Windows, the easiest way is to use Microsoft Visual Studio, put all files into a C++ project, set include and library paths for OpenCV and optionally OpenCL, and finally compile and run the program
 
 
-## Documentation
+## Usage
 
-### Python
+### Python GUI
 
-Command line options of `main.py`:
-* `--data`: directory containing the input images
-* `--optim_algo`: either do grid search ('grid'), or apply Powell's derivative-free optimizer ('powell')
+Command line options of `DeslantImgPlot`:
+* `--data`: directory containing the (.png|.jpg|.bmp) input images
+* `--optim_algo`: either do grid search (`grid`), or apply Powell's derivative-free optimizer (`powell`)
 * `--lower_bound`: lower bound of shear values
 * `--upper_bound`: upper bound of shear values
 * `--num_steps`: if grid search is used, this argument defines the number if grid points
 * `--bg_color`: color to fill the gaps of the sheared image that is returned
 
 
-### C++
-Call function ```deslantImg(img, bgcolor)``` with the input image (grayscale), and the background color (to fill empty image space).
+### C++ API
+Call function `deslantImg(img, bgcolor)` with the input image (grayscale), and the background color (to fill empty image space).
 It returns the deslanted image computed on the **CPU**.
 
-```
+```C++
 #include "DeslantImgCPU.hpp"
 ...
 
@@ -72,11 +76,11 @@ const cv::Mat res = htr::deslantImg(img, 255);
 cv::imwrite("out1.png", res);
 ```
 
-### OpenCL
-The GPU version additionally takes an instance of ```CLWrapper``` which holds all relevant information needed for OpenCL: ```deslantImg(img, bgcolor, clWrapper)```.
-As the construction of a ```CLWrapper``` instance takes time, it makes sense to only create one instance and use it for all future calls to ```deslantImg(img, bgcolor, clWrapper)```. 
+### OpenCL API
+The GPU version additionally takes an instance of `CLWrapper` which holds all relevant information needed for OpenCL: `deslantImg(img, bgcolor, clWrapper)`.
+As the construction of a `CLWrapper` instance takes time, it makes sense to only create one instance and use it for all future calls to `deslantImg(img, bgcolor, clWrapper)`. 
 
-```
+```C++
 #include "DeslantImgGPU.hpp"
 ...
 
@@ -94,7 +98,7 @@ cv::imwrite("out1.png", res);
 
 ## Algorithm 
 
-Vinciarelli and Luettin describe the algorithm in their paper.
+Vinciarelli and Luettin describe the algorithm in their [2001 paper](http://dx.doi.org/10.1016/S0167-8655(01)00042-3).
 Here is a short outline of the algorithm:
 
 ![algo](doc/algo.png)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-matplotlib==3.3.3
-numpy==1.19.3
-opencv-python==4.4.0.46
-path==15.0.1
-Py-BOBYQA==1.3
+matplotlib>=3.3.3
+numpy>=1.19.3
+opencv-python>=4.4.0
+path>=15.0
+Py-BOBYQA>=1.3

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+"""
+Installs:
+    - DeslantImgPlot
+"""
+
+import codecs
+import json
+from setuptools import setup
+
+with codecs.open('README.md', encoding='utf-8') as f:
+    README = f.read()
+
+setup(
+    name='DeslantImg',
+    description='The deslanting algorithm sets text upright in images',
+    long_description=README,
+    long_description_content_type='text/markdown',
+    author='Harald Scheidl',
+    url='https://github.com/githubharald/DeslantImg',
+    license='MIT',
+    py_modules=['main', 'deslant'],
+    package_dir={'': 'src/py'},
+    install_requires=open('requirements.txt').read().split('\n'),
+    entry_points={
+        'console_scripts': [
+            'DeslantImgPlot=main:main',
+        ]
+    },
+)

--- a/src/cpp/DeslantImgCPU.cpp
+++ b/src/cpp/DeslantImgCPU.cpp
@@ -22,7 +22,7 @@ namespace htr
 	// * img: grayscale image containing text
 	// * bgcolor: empty space in result image is filled with this color (0...255)
 	// * returns: deslanted image
-	cv::Mat deslantImg(const cv::Mat& img, const int bgcolor)
+	cv::Mat deslantImg(const cv::Mat& img, const int bgcolor, const float lower_bound, const float upper_bound)
 	{
 		// must be grayscale img
 		assert(img.channels() == 1);
@@ -44,6 +44,10 @@ namespace htr
 			Result result;
 
 			const float alpha = alphaVals[i];
+			if (alpha < lower_bound)
+				continue;
+			if (alpha > upper_bound)
+				break;
 			const float shiftX = std::max(-alpha*imgBW.rows, 0.0f);
 			result.size = cv::Size(imgBW.cols + static_cast<int>(std::ceil(std::abs(alpha*imgBW.rows))), imgBW.rows);
 

--- a/src/cpp/DeslantImgCPU.hpp
+++ b/src/cpp/DeslantImgCPU.hpp
@@ -9,7 +9,7 @@ namespace htr
 	// * img: grayscale image containing text
 	// * bgcolor: empty space in result image is filled with this color (0...255)
 	// * returns: deslanted image
-	cv::Mat deslantImg(const cv::Mat& img, const int bgcolor);
+	cv::Mat deslantImg(const cv::Mat& img, const int bgcolor, const float lower_bound=-1.0, const float upper_bound=1.0);
 
 }
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -5,30 +5,70 @@
 #endif
 #include <opencv2/imgcodecs.hpp>
 #include <iostream>
+#include <list>
 
 
-int main() 
+int main(int argc, const char *argv[])
 {
-	// load input image
-	const cv::Mat img1 = cv::imread("data/test1.png", cv::IMREAD_GRAYSCALE);
-	const cv::Mat img2 = cv::imread("data/test2.png", cv::IMREAD_GRAYSCALE);
-	
-	
-#ifdef USE_GPU 
-	// deslant on GPU
-	htr::CLWrapper clWrapper; // setup OpenCL, the same instance should be used for all following calls to deslantImg
-	const cv::Mat res1 = htr::deslantImg(img1, 255, clWrapper);
-	const cv::Mat res2 = htr::deslantImg(img2, 255, clWrapper);
+	const cv::String opts =
+		"{help h usage ? |      | print this message   }"
+		"{data           |data  | directory to read the input images from }"
+		"{dataout        |.     | directory to write the output images to }"
+		"{lower_bound    |-1.0  | lower bound of shear values }"
+		"{upper_bound    |1.0   | upper bound of shear values }"
+		"{bg_color       |255   | color to fill the gaps of the sheared image that is returned }"
+		;
+	cv::CommandLineParser parser(argc, argv, opts);
+#ifdef USE_GPU
+	parser.about("DeslantImg GPU");
 #else
-	// deslant on CPU
-	cv::Mat res1 = htr::deslantImg(img1, 255);
-	cv::Mat res2 = htr::deslantImg(img2, 255);
+	parser.about("DeslantImg CPU");
 #endif
-
-	// write results to file
-	cv::imwrite("out1.png", res1);
-	cv::imwrite("out2.png", res2);
-
+	if (parser.has("help"))
+	{
+		parser.printMessage();
+		return 0;
+	}
+	if (!parser.check())
+	{
+		parser.printErrors();
+		return 1;
+	}
+	cv::String inpath = parser.get<cv::String>("data");
+	cv::String outpath = parser.get<cv::String>("dataout");
+	float lower_bound = parser.get<float>("lower_bound");
+	float upper_bound = parser.get<float>("upper_bound");
+	int bg_color = parser.get<int>("bg_color");
+	
+	std::list<cv::String> files;
+	std::vector<cv::String> extfiles;
+	std::vector<cv::String> extensions { ".png", ".jpg", ".bmp" };
+	for (const cv::String& ext : extensions)
+	{
+		cv::glob(inpath + "/*" + ext, extfiles);
+		for (const cv::String& file : extfiles)
+			files.push_back(file);
+	}
+#ifdef USE_GPU
+	htr::CLWrapper clWrapper; // setup OpenCL, the same instance should be used for all following calls to deslantImg
+#endif
+	for (const cv::String & file : files)
+	{
+		std::cout << "Reading '" << file << "'" << std::endl;
+		// load input image
+		const cv::Mat img = cv::imread(file, cv::IMREAD_GRAYSCALE);
+#ifdef USE_GPU 
+		// deslant on GPU
+		const cv::Mat res = htr::deslantImg(img, bg_color, clWrapper);
+#else
+		// deslant on CPU
+		cv::Mat res = htr::deslantImg(img, bg_color, lower_bound, upper_bound);
+#endif
+		// write result to file
+		cv::String out = outpath + "/" + file.substr(file.find_last_of("/\\") + 1);
+		std::cout << "Writing '" << out << "'" << std::endl;
+		cv::imwrite(out, res);
+	}
 	return 0;
 }
 

--- a/src/py/main.py
+++ b/src/py/main.py
@@ -20,12 +20,18 @@ def get_img_files(data_dir: Path) -> List[Path]:
 def parse_args():
     """Parses command line args."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data', type=Path, default=Path('../../data/'))
-    parser.add_argument('--optim_algo', choices=['grid', 'powell'], default='grid')
-    parser.add_argument('--lower_bound', type=float, default=-2)
-    parser.add_argument('--upper_bound', type=float, default=2)
-    parser.add_argument('--num_steps', type=float, default=20)
-    parser.add_argument('--bg_color', type=int, default=255)
+    parser.add_argument('--data', type=Path, default=Path('../../data/'),
+                        help='directory containing the (.png|.jpg|.bmp) input images')
+    parser.add_argument('--optim_algo', choices=['grid', 'powell'], default='grid',
+                        help='either do grid search, or apply Powell\'s derivative-free optimizer')
+    parser.add_argument('--lower_bound', type=float, default=-2, metavar='LO',
+                        help='lower bound of shear values')
+    parser.add_argument('--upper_bound', type=float, default=2, metavar='HI',
+                        help='upper bound of shear values')
+    parser.add_argument('--num_steps', type=float, default=20, metavar='STEPS',
+                        help='if grid search is used, this argument defines the number if grid points')
+    parser.add_argument('--bg_color', type=int, default=255, metavar='BG',
+                        help='color to fill the gaps of the sheared image that is returned')
 
     return parser.parse_args()
 


### PR DESCRIPTION
Just trying to improve UX. After encapsulating the Python binding into a pkg with entry point, I went after the C++ (build and) demo CLI: why not make it as versatile as the Python CLI (i.e. process arbitrary images, pass alpha boundaries and bg level)? Also contains a simple makefile (as alternative to build.sh) and updates to the README.

Note that I have not yet managed to make passing `--upper_bound` / `--lower_bound` to the OpenCL implementation...